### PR TITLE
[実装]ToDo追加機能のバリデーション

### DIFF
--- a/app/presentation/controllers/AddTaskRequest.scala
+++ b/app/presentation/controllers/AddTaskRequest.scala
@@ -3,7 +3,7 @@ package presentation.controllers
 import domain.model.task.Category
 import play.api.libs.json.{ Json, Reads }
 
-case class AddTaskRequest(title: String, body: String, categoryId: Option[Category.Id]) // TODO
+case class AddTaskRequest(title: String, body: String, categoryId: Option[Category.Id])
 
 object AddTaskRequest {
   implicit val reads: Reads[AddTaskRequest] = Json.reads[AddTaskRequest]

--- a/app/presentation/controllers/AddTaskRequest.scala
+++ b/app/presentation/controllers/AddTaskRequest.scala
@@ -1,10 +1,16 @@
 package presentation.controllers
 
 import domain.model.task.Category
-import play.api.libs.json.{ Json, Reads }
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.Reads.pattern
+import play.api.libs.json.{ JsPath, Reads }
 
 case class AddTaskRequest(title: String, body: String, categoryId: Option[Category.Id])
 
 object AddTaskRequest {
-  implicit val reads: Reads[AddTaskRequest] = Json.reads[AddTaskRequest]
+  implicit val reads: Reads[AddTaskRequest] = (
+    (JsPath \ "title").read[String](pattern("^[a-zA-Z0-9\u3041-\u309A\u30A1-\u30FF\u4E00-\u9FAF]+$".r, "The title must contain only alphanumeric characters (a-z, A-Z, 0-9), Hiragana, Katakana, or Kanji. Space and newline characters are prohibited.")) and
+      (JsPath \ "body").read[String](pattern("^[a-zA-Z0-9\u3041-\u309A\u30A1-\u30FF\u4E00-\u9FAF \u3000\r\n]*$".r, "The body must consist of alphanumeric characters (a-z, A-Z, 0-9), Hiragana, Katakana, Kanji, spaces, or newlines.")) and
+      (JsPath \ "categoryId").readNullable[Category.Id]
+  )(AddTaskRequest.apply _)
 }

--- a/app/presentation/controllers/HomeController.scala
+++ b/app/presentation/controllers/HomeController.scala
@@ -6,6 +6,7 @@ package presentation.controllers
 
 import domain.model.task.Task
 import ixias.play.api.mvc.JsonHelper
+import play.api.libs.json.JsObject
 import play.api.mvc._
 import presentation.views
 import presentation.views.model.ViewValueHome
@@ -43,7 +44,7 @@ class HomeController @Inject() (
     JsonHelper.bindFromRequest[AddTaskRequest].fold(
       formWithErrors => Future(formWithErrors),
       addTaskRequest =>
-        addTaskUseCase.execute(Task(addTaskRequest)).map(_ => Redirect(routes.HomeController.index()))
+        addTaskUseCase.execute(Task(addTaskRequest)).map(_ => Ok(JsObject.empty))
     )
   }
 }

--- a/app/presentation/views/task/Add.scala.html
+++ b/app/presentation/views/task/Add.scala.html
@@ -54,28 +54,29 @@
     })
     .then(response => {
       if (response.ok) {
-        return response.json();
+        const newTask = response.json();
+        alert('successfully added. please reload.'); // TODO ここで画面を非同期に更新する
+        document.getElementById('taskForm').reset();
       } else {
-        return response.json().then(error => {
-          throw error;
+        response.json().then(error => {
+          console.error('Error:',error)
+          let message = '';
+          if (error.hasOwnProperty('obj.title')) {
+            message += error['obj.title'][0].msg[0];
+          }
+          if (error.hasOwnProperty('obj.body')) {
+            message += error['obj.body'][0].msg[0];
+          }
+          if (message == '') {
+            message = 'An unexpected validation error occurred. ';
+          }
+          alert('Failed to add. ' + message);
         });
       }
     })
-    .then(newTask => {
-      alert('successfully added. please reload.'); // TODO ここで画面を非同期に更新する
-      document.getElementById('taskForm').reset();
-    })
     .catch(error => {
       console.error('Error:', error);
-      let key;
-      if (error.hasOwnProperty('obj.title')) {
-        key = 'obj.title'
-      } else if (error.hasOwnProperty('obj.body')) {
-        key = 'obj.body'
-      } else {
-        key = 'obj.categoryId'
-      }
-      alert('Failed to add. ' + error[key][0].msg[0]);
+      alert('An unexpected issue has occurred. ')
     });
   }
 </script>

--- a/app/presentation/views/task/Add.scala.html
+++ b/app/presentation/views/task/Add.scala.html
@@ -52,13 +52,30 @@
       },
       body: JSON.stringify(jsonData)
     })
-    .then(data => {
-      console.log('Success:', data);
-      // 送信成功時の処理（例：メッセージ表示、画面遷移など）
+    .then(response => {
+      if (response.ok) {
+        return response.json();
+      } else {
+        return response.json().then(error => {
+          throw error;
+        });
+      }
     })
-    .catch((error) => {
+    .then(newTask => {
+      alert('successfully added. please reload.'); // TODO ここで画面を非同期に更新する
+      document.getElementById('taskForm').reset();
+    })
+    .catch(error => {
       console.error('Error:', error);
-      // エラー発生時の処理
+      let key;
+      if (error.hasOwnProperty('obj.title')) {
+        key = 'obj.title'
+      } else if (error.hasOwnProperty('obj.body')) {
+        key = 'obj.body'
+      } else {
+        key = 'obj.categoryId'
+      }
+      alert('Failed to add. ' + error[key][0].msg[0]);
     });
   }
 </script>

--- a/app/presentation/views/task/Add.scala.html
+++ b/app/presentation/views/task/Add.scala.html
@@ -47,6 +47,7 @@
     fetch('/task', {
       method: 'POST',
       headers: {
+        'Accept': 'application/json',
         'Content-Type': 'application/json',
         'Csrf-Token': csrfToken // ここで取得したトークンを設定
       },

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,3 +17,6 @@ ixias.db.mysql {
 }
 
 play.modules.enabled += "infrastructure.modules.DatabaseModule"
+
+# リクエストヘッダのAcceptに応じてレスポンスの形式をHTMLまたはJONにする
+play.http.errorHandler = play.api.http.HtmlOrJsonHttpErrorHandler


### PR DESCRIPTION
### 各入力フォームの制約
- title: 
  - 英数字、ひらがな、カタカナ、日本語の1文字以上からなる文字列
  - 記号や空白、特に要件とされる改行は不可
- body: 
  - 英数字、ひらがな、カタカナ、日本語、半角空白、全角空白、改行の0文字以上からなる文字列
  - 記号、特に句読点なども不可
- cateogry: 
  - なし（ラジオボタンに埋め込んだcategoryIdを送信するため）

### バリデーションエラーの表示
- titleとbodyがともにエラーの場合、titleがエラーとして画面に表示される()

### 実装していないこと
- バリデーションのテスト（レビューしづらくてすみません...）
- bodyには改行が許されているが、表示は空白扱いになっている。


https://github.com/user-attachments/assets/9a530262-6568-426c-af6f-89f6ff0b2a68