### PR TITLE
[実装]ToDo更新機能（バリデーションと非同期更新を含む）

### DIFF
--- a/app/domain/model/task/Category.scala
+++ b/app/domain/model/task/Category.scala
@@ -19,6 +19,7 @@ object Category extends JsonEnvReads {
   val Id = the[Identity[Id]]
   type Id = Long @@ Category
 
+  implicit val writes: Writes[Id] = (o: Id) => JsNumber(Id.unwrap(o))
   implicit val reads: Reads[Id] = idAsNumberReads[Id]
 }
 

--- a/app/domain/model/task/Task.scala
+++ b/app/domain/model/task/Task.scala
@@ -4,6 +4,7 @@ import domain.model.task.Status.Todo
 import ixias.model._
 import ixias.util.EnumStatus
 import play.api.libs.json._
+import ixias.util.json.JsonEnvReads
 
 import java.time.LocalDateTime
 
@@ -15,10 +16,12 @@ case class Task(
   state:      Status        = Todo,
   updatedAt:  LocalDateTime = NOW,
   createdAt:  LocalDateTime = NOW
-) extends EntityModel[Task.Id]
-object Task {
+)           extends EntityModel[Task.Id]
+object Task extends JsonEnvReads {
   val Id = the[Identity[Id]]
   type Id = Long @@ Task
+
+  implicit val reads: Reads[Id] = idAsNumberReads[Id]
 }
 
 sealed abstract class Status(val code: Short, val name: String) extends EnumStatus
@@ -32,4 +35,7 @@ object Status extends EnumStatus.Of[Status] {
       "code" -> JsNumber(o.code),
       "name" -> JsString(o.name)
     ))
+
+  object Reads extends JsonEnvReads
+  implicit val reads: Reads[Status] = Reads.enumReads[Status](Status)
 }

--- a/app/domain/model/task/Task.scala
+++ b/app/domain/model/task/Task.scala
@@ -21,6 +21,7 @@ object Task extends JsonEnvReads {
   val Id = the[Identity[Id]]
   type Id = Long @@ Task
 
+  implicit val writes: Writes[Task.Id] = (o: Task.Id) => JsNumber(Id.unwrap(o))
   implicit val reads: Reads[Id] = idAsNumberReads[Id]
 }
 

--- a/app/infrastructure/task/TaskQueryServiceImpl.scala
+++ b/app/infrastructure/task/TaskQueryServiceImpl.scala
@@ -18,7 +18,7 @@ class TaskQueryServiceImpl @Inject() (
   def fetchAll(): Future[Seq[TaskItemDto]] = {
     val showData = for {
       (task, category) <- taskTable joinLeft categoryTable on (_.categoryId === _.id)
-    } yield (task.title, task.body, task.state, category.map(_.name), category.map(_.color))
+    } yield (task.id, task.title, task.body, task.state, category.map(_.id), category.map(_.name), category.map(_.color))
     slave.run(showData.result).map(_.map((TaskItemDto.apply _).tupled))
   }
 

--- a/app/presentation/controllers/HomeController.scala
+++ b/app/presentation/controllers/HomeController.scala
@@ -29,9 +29,10 @@ class HomeController @Inject() (
 
     val tasksFuture      = showTaskUseCase.execute()
     val categoriesFuture = showCategoryUseCase.execute()
+    val allState         = domain.model.task.Status.values
     for {
       tasks      <- tasksFuture
       categories <- categoriesFuture
-    } yield Ok(views.html.Task(vv, tasks, categories))
+    } yield Ok(views.html.Task(vv, tasks, categories, allState))
   }
 }

--- a/app/presentation/controllers/TaskController.scala
+++ b/app/presentation/controllers/TaskController.scala
@@ -7,7 +7,7 @@ package presentation.controllers
 import ixias.play.api.mvc.JsonHelper
 import play.api.libs.json.Json
 import play.api.mvc._
-import usecase.task.AddTaskUseCase
+import usecase.task.{ AddTaskUseCase, UpdateTaskUseCase }
 
 import javax.inject._
 import scala.concurrent.Future
@@ -15,7 +15,8 @@ import scala.concurrent.Future
 @Singleton
 class TaskController @Inject() (
   val controllerComponents: ControllerComponents,
-  addTaskUseCase:           AddTaskUseCase
+  addTaskUseCase:           AddTaskUseCase,
+  updateTaskUseCase:        UpdateTaskUseCase
 ) extends BaseController {
   implicit val ec: scala.concurrent.ExecutionContext = controllerComponents.executionContext
 
@@ -24,6 +25,14 @@ class TaskController @Inject() (
       Future.successful,
       addTaskRequest =>
         addTaskUseCase.execute(addTaskRequest).map(task => Ok(Json.toJson(task)))
+    )
+  }
+
+  def update() = Action.async { implicit request =>
+    JsonHelper.bindFromRequest[UpdateTaskRequest].fold(
+      Future.successful,
+      updateTaskRequest =>
+        updateTaskUseCase.execute(updateTaskRequest).map(task => Ok(Json.toJson(task)))
     )
   }
 }

--- a/app/presentation/controllers/UpdateTaskRequest.scala
+++ b/app/presentation/controllers/UpdateTaskRequest.scala
@@ -1,7 +1,9 @@
 package presentation.controllers
 
-import domain.model.task.{Category, Status, Task}
-import play.api.libs.json.{Json, Reads}
+import domain.model.task.{ Category, Status, Task }
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.Reads.pattern
+import play.api.libs.json.{ JsPath, Reads }
 
 case class UpdateTaskRequest(
   id:         Task.Id,
@@ -11,5 +13,17 @@ case class UpdateTaskRequest(
   categoryId: Option[Category.Id]
 )
 object UpdateTaskRequest {
-  implicit val reads: Reads[UpdateTaskRequest] = Json.reads[UpdateTaskRequest]
+  implicit val reads: Reads[UpdateTaskRequest] = (
+    (JsPath \ "id").read[Task.Id] and
+      (JsPath \ "title").read[String](pattern(
+        "^[a-zA-Z0-9\u3041-\u309A\u30A1-\u30FF\u4E00-\u9FAF]+$".r,
+        "The title must contain only alphanumeric characters (a-z, A-Z, 0-9), Hiragana, Katakana, or Kanji. Space and newline characters are prohibited."
+      )) and
+      (JsPath \ "body").read[String](pattern(
+        "^[a-zA-Z0-9\u3041-\u309A\u30A1-\u30FF\u4E00-\u9FAF \u3000\r\n]*$".r,
+        "The body must consist of alphanumeric characters (a-z, A-Z, 0-9), Hiragana, Katakana, Kanji, spaces, or newlines."
+      )) and
+      (JsPath \ "state").read[Status] and
+      (JsPath \ "categoryId").readNullable[Category.Id]
+  )(UpdateTaskRequest.apply _)
 }

--- a/app/presentation/controllers/UpdateTaskRequest.scala
+++ b/app/presentation/controllers/UpdateTaskRequest.scala
@@ -1,0 +1,15 @@
+package presentation.controllers
+
+import domain.model.task.{Category, Status, Task}
+import play.api.libs.json.{Json, Reads}
+
+case class UpdateTaskRequest(
+  id:         Task.Id,
+  title:      String,
+  body:       String,
+  state:      Status,
+  categoryId: Option[Category.Id]
+)
+object UpdateTaskRequest {
+  implicit val reads: Reads[UpdateTaskRequest] = Json.reads[UpdateTaskRequest]
+}

--- a/app/presentation/views/Task.scala.html
+++ b/app/presentation/views/Task.scala.html
@@ -24,4 +24,4 @@
 </ul>
 }
 
-@task.Update(categories, allState, nullCategoryName)
+@task.Update(categories, allState, nullCategoryName, nullCategoryColor)

--- a/app/presentation/views/Task.scala.html
+++ b/app/presentation/views/Task.scala.html
@@ -1,7 +1,8 @@
 @import usecase.task._
+@import domain.model.task.Status
 @import helper._
 @import presentation.controllers._
-@(vv: presentation.views.model.ViewValueCommon, tasks: Seq[TaskItemDto], categories: Seq[ShowCategoryUseCaseDto])(implicit request: MessagesRequestHeader)
+@(vv: presentation.views.model.ViewValueCommon, tasks: Seq[TaskItemDto], categories: Seq[ShowCategoryUseCaseDto], allState: Seq[Status])(implicit request: MessagesRequestHeader)
 
 @nullCategoryName = @{"未分類"}
 @nullCategoryColor = @{"#000000"}
@@ -15,10 +16,12 @@
           @task.TaskItem(nullCategoryName, nullCategoryColor)
           <script>
           @tasks.map{task =>
-              appendChildFromTemplate('@task.title', '@{task.categoryName.getOrElse(nullCategoryName)}', '@{task.categoryColor.fold(nullCategoryColor)(_.hexCode)}', '@task.state.name', '@task.body')
+              appendChildFromTemplate('@task.id','@task.title', '@{task.categoryId.getOrElse(null)}', '@{task.categoryName.getOrElse(nullCategoryName)}', '@{task.categoryColor.fold(nullCategoryColor)(_.hexCode)}', '@task.state.code', '@task.state.name', '@task.body')
           }
           </script>
       </ul>
     </li>
 </ul>
 }
+
+@task.Update(categories, allState, nullCategoryName)

--- a/app/presentation/views/task/Add.scala.html
+++ b/app/presentation/views/task/Add.scala.html
@@ -54,7 +54,7 @@
     .then(response => {
       if (response.ok) {
         response.json().then(task => {
-          appendChildFromTemplate(task.title, task.categoryName, task.categoryColor?.hexCode || null , task.state.name, task.body);
+          appendChildFromTemplate(task.id, task.title, task.categoryId, task.categoryName, task.categoryColor?.hexCode || null , task.state.code, task.state.name, task.body);
           document.getElementById('taskForm').reset();
         });
       } else {

--- a/app/presentation/views/task/TaskItem.scala.html
+++ b/app/presentation/views/task/TaskItem.scala.html
@@ -1,20 +1,22 @@
 @(nullCategoryName: String, nullCategoryColor: String)
 
 <template id="taskItemTemplate">
-  <li>
+  <li class="taskItem" value="">
     <div><a class="title" style="width: 800px;"></a>
       <a class="categoryName" style="background-color: @nullCategoryColor; color: white; padding: 2px; border-radius: 5px;">
         @nullCategoryName</a><a class="status"></a>
     </div>
-    <div class="body" style="padding-left: 40px; margin-bottom: 20px;"></div>
+    <div class="body" style="padding-left: 40px;"></div>
+    <button class="editButton"  style="margin-bottom: 20px;">編集</button>
   </li>
 </template>
 
 <script>
-  function appendChildFromTemplate(title, categoryName, colorHexCode, status, body) {
+  function appendChildFromTemplate(id, title, categoryId, categoryName, colorHexCode, stateCode, stateName, body) {
     if ("content" in document.createElement('template')) {
       var template = document.getElementById('taskItemTemplate');
       var clone = template.content.cloneNode(true);
+      clone.querySelector('.taskItem').value = id;
       clone.querySelector('.title').textContent = title;
       if (categoryName) {
         clone.querySelector('.categoryName').textContent = categoryName;
@@ -22,8 +24,11 @@
       if (colorHexCode) {
         clone.querySelector('.categoryName').style.backgroundColor = colorHexCode;
       };
-      clone.querySelector('.status').textContent = status;
+      clone.querySelector('.status').textContent = stateName;
       clone.querySelector('.body').textContent = body;
+      clone.querySelector('.editButton').addEventListener('click',() =>
+        showEditForm(id, title, categoryId, stateCode, body)
+      );
       document.getElementById('taskList').appendChild(clone);
     } else {
       console.error('Unsupported Feature: The HTML <template> element is not recognized by your browser.')

--- a/app/presentation/views/task/Update.scala.html
+++ b/app/presentation/views/task/Update.scala.html
@@ -114,8 +114,17 @@
          } else {
            response.json().then(error => {
             console.error('Validation Error: ',error)
-            // TODO バリデーションエラー処理
-            alert('Failed to update. ');
+            let message = '';
+            if (error.hasOwnProperty('obj.title')) {
+              message += error['obj.title'][0].msg[0];
+            }
+            if (error.hasOwnProperty('obj.body')) {
+              message += error['obj.body'][0].msg[0];
+            }
+            if (message == '') {
+              message = 'An unexpected validation error occurred. ';
+            }
+            alert('Failed to update todo. ' + message);
            });
          };
        })

--- a/app/presentation/views/task/Update.scala.html
+++ b/app/presentation/views/task/Update.scala.html
@@ -1,7 +1,7 @@
 @import domain.model.task.Status
 @import usecase.task.ShowCategoryUseCaseDto
 @import helper._
-@(categories: Seq[ShowCategoryUseCaseDto], allState: Seq[Status], nullCategoryName: String)(implicit request: MessagesRequestHeader)
+@(categories: Seq[ShowCategoryUseCaseDto], allState: Seq[Status], nullCategoryName: String, nullCategoryColor: String)(implicit request: MessagesRequestHeader)
 
 <div id="editModalOverlay" class="modal-overlay" style="display: none;">
     <div id="editModalContent" class="modal-content">
@@ -108,7 +108,7 @@
        .then(response => {
          if (response.ok) {
            response.json().then(task => {
-             // TODO Todoリストを非同期更新
+             updateTaskItem(task.id, task.title, task.categoryId, task.categoryName, task.categoryColor?.hexCode, task.state.code, task.state.name, task.body)
              closeEditModal();
            });
          } else {
@@ -124,6 +124,19 @@
          alert('An unexpected issue has occurred. ')
        });
   };
+
+  function updateTaskItem(id, title, categoryId, categoryName, colorHexCode, stateCode, stateName, body) {
+    const taskItem = document.getElementById('taskList').querySelector(`[value="${id}"]`);
+    taskItem.querySelector('.title').textContent = title;
+    taskItem.querySelector('.categoryName').textContent = categoryName || '@nullCategoryName';
+    taskItem.querySelector('.categoryName').style.backgroundColor = colorHexCode || '@nullCategoryColor';
+    taskItem.querySelector('.status').textContent = stateName;
+    taskItem.querySelector('.body').textContent = body;
+    taskItem.querySelector('.editButton').addEventListener('click',() =>
+      showEditForm(id, title, categoryId, stateCode, body)
+    );
+  };
+
   function closeEditModal() {
     editModalOverlay.style.display = 'none';
   };

--- a/app/presentation/views/task/Update.scala.html
+++ b/app/presentation/views/task/Update.scala.html
@@ -1,0 +1,130 @@
+@import domain.model.task.Status
+@import usecase.task.ShowCategoryUseCaseDto
+@import helper._
+@(categories: Seq[ShowCategoryUseCaseDto], allState: Seq[Status], nullCategoryName: String)(implicit request: MessagesRequestHeader)
+
+<div id="editModalOverlay" class="modal-overlay" style="display: none;">
+    <div id="editModalContent" class="modal-content">
+        <h2>Todo編集</h2>
+        <form id="taskUpdateForm">
+            @CSRF.formField
+            <input type="hidden" id="updateTaskId" name="id">
+            <div>
+                <label for="updateTaskTitle">タイトル:</label>
+                <input type="text" id="updateTaskTitle" name="title">
+            </div>
+            <div>
+                <label for="updateTaskBody">内容:</label>
+                <textarea id="updateTaskBody" name="body"></textarea>
+            </div>
+            <div>
+                <label>カテゴリ:</label>
+                @for(category <- categories) {
+                <input type="radio" id="updateTaskCategoryId_@category.id" name="updateTaskCategoryRadio" value="@category.id">
+                <label for="updateTaskCategoryId_@category.id">@category.name</label>
+                }
+                <input type="radio" id="updateTaskCategoryId_null" name="updateTaskCategoryRadio" value="">
+                <label for="updateTaskCategoryId_null">@nullCategoryName</label>
+            </div>
+            <div>
+                <label>ステータス:</label>
+                @for(state <- allState) {
+                <input type="radio" id="updateTaskStatusCode_@state.code" name="updateTaskStatusRadio" value="@state.code">
+                <label for="updateTaskStatusCode_@state.code">@state.name</label>
+                }
+            </div>
+            <button type="button" onclick="sendUpdatedTaskData()">更新</button>
+            <button id="updateTaskResetButton" type="button">リセット</button>
+        </form>
+        <button type="button" onclick="closeEditModal()">閉じる</button>
+    </div>
+</div>
+
+<style>
+    /* ポップアップのスタイル (例) */
+    .modal-overlay {
+      display: none; /* 初期状態は非表示 */
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.5); /* 半透明の背景 */
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+    }
+    .modal-content {
+      background-color: white;
+      padding: 20px;
+      border-radius: 5px;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    }
+</style>
+
+<script>
+  function showEditForm(id, title, categoryId, stateCode, body) {
+    document.getElementById('updateTaskId').value = id;
+    document.getElementById('updateTaskTitle').value = title;
+    document.getElementById('updateTaskCategoryId_' + (categoryId || "null")).checked = true;
+    document.getElementById('updateTaskStatusCode_' + stateCode).checked = true;
+    document.getElementById('updateTaskBody').value = body;
+    document.getElementById('updateTaskResetButton').addEventListener('click',() =>
+        showEditForm(id, title, categoryId, stateCode, body)
+      );
+    editModalOverlay.style.display = 'flex';
+  };
+
+  function sendUpdatedTaskData() {
+    const id = parseInt(document.getElementById('updateTaskId').value);
+    const title = document.getElementById('updateTaskTitle').value;
+    const body = document.getElementById('updateTaskBody').value;
+    const categoryIdElement = document.querySelector('input[name="updateTaskCategoryRadio"]:checked');
+    const categoryId = parseInt(categoryIdElement.value) || null;
+    const statusCodeElement = document.querySelector('input[name="updateTaskStatusRadio"]:checked');
+    let statusCode;
+    if (statusCodeElement) {
+      statusCode = parseInt(statusCodeElement.value);
+    } else {
+      alert('Please select status.');
+    }
+    const requestData = {
+      id: id,
+      title: title,
+      body: body,
+      categoryId: categoryId,
+      state: statusCode
+    };
+
+    fetch('/task', {
+         method: 'PUT',
+         headers: {
+           'Accept': 'application/json',
+           'Content-Type': 'application/json',
+           'Csrf-Token': csrfToken
+         },
+         body: JSON.stringify(requestData)
+       })
+       .then(response => {
+         if (response.ok) {
+           response.json().then(task => {
+             // TODO Todoリストを非同期更新
+             closeEditModal();
+           });
+         } else {
+           response.json().then(error => {
+            console.error('Validation Error: ',error)
+            // TODO バリデーションエラー処理
+            alert('Failed to update. ');
+           });
+         };
+       })
+       .catch(error => {
+         console.error('TaskUpdateError:', error);
+         alert('An unexpected issue has occurred. ')
+       });
+  };
+  function closeEditModal() {
+    editModalOverlay.style.display = 'none';
+  };
+</script>

--- a/app/usecase/task/AddTaskUseCase.scala
+++ b/app/usecase/task/AddTaskUseCase.scala
@@ -20,16 +20,18 @@ class AddTaskUseCase @Inject() (
       body       = addTaskRequest.body,
       categoryId = addTaskRequest.categoryId
     ).toWithNoId
-    val execution      = taskRepository.add(taskWithNoId)
+    val taskIdFuture   = taskRepository.add(taskWithNoId)
     val task           = taskWithNoId.v
     val categoryFuture = task.categoryId.fold(Future.successful(none[Category]))(taskQueryService.getCategoryById)
     for {
-      _        <- execution
+      taskId   <- taskIdFuture
       category <- categoryFuture
     } yield TaskItemDto(
+      id            = taskId,
       title         = task.title,
       body          = task.body,
       state         = task.state,
+      categoryId    = task.categoryId,
       categoryName  = category.map(_.name),
       categoryColor = category.map(_.color)
     )

--- a/app/usecase/task/TaskItemDto.scala
+++ b/app/usecase/task/TaskItemDto.scala
@@ -1,12 +1,14 @@
 package usecase.task
 
-import domain.model.task.{ Color, Status }
-import play.api.libs.json.{ Json, OWrites }
+import domain.model.task.{Category, Color, Status, Task}
+import play.api.libs.json.{Json, OWrites}
 
 case class TaskItemDto(
+  id:            Task.Id,
   title:         String,
   body:          String,
   state:         Status,
+  categoryId : Option[Category.Id],
   categoryName:  Option[String],
   categoryColor: Option[Color]
 )

--- a/app/usecase/task/UpdateTaskUseCase.scala
+++ b/app/usecase/task/UpdateTaskUseCase.scala
@@ -1,0 +1,37 @@
+package usecase.task
+
+import cats.implicits.none
+import domain.model.task.{ Category, Task, TaskRepository }
+import presentation.controllers.UpdateTaskRequest
+
+import javax.inject.{ Inject, Singleton }
+import scala.concurrent.{ ExecutionContext, Future }
+
+@Singleton
+class UpdateTaskUseCase @Inject() (
+  taskRepository:                TaskRepository,
+  taskQueryService:              TaskQueryService,
+  implicit val executionContext: ExecutionContext
+) {
+  def execute(updateTaskRequest: UpdateTaskRequest): Future[TaskItemDto] = {
+    val newTask        = Task(
+      id         = Some(updateTaskRequest.id),
+      categoryId = updateTaskRequest.categoryId,
+      title      = updateTaskRequest.title,
+      body       = updateTaskRequest.body,
+      state      = updateTaskRequest.state
+    )
+    val execution      = taskRepository.update(newTask.toEmbeddedId)
+    val categoryFuture = newTask.categoryId.fold(Future.successful(none[Category]))(taskQueryService.getCategoryById)
+    for {
+      _        <- execution
+      category <- categoryFuture
+    } yield TaskItemDto(
+      title         = newTask.title,
+      body          = newTask.body,
+      state         = newTask.state,
+      categoryName  = category.map(_.name),
+      categoryColor = category.map(_.color)
+    )
+  }
+}

--- a/app/usecase/task/UpdateTaskUseCase.scala
+++ b/app/usecase/task/UpdateTaskUseCase.scala
@@ -2,6 +2,8 @@ package usecase.task
 
 import cats.implicits.none
 import domain.model.task.{ Category, Task, TaskRepository }
+import play.api.libs.json.JsError
+import play.api.libs.json.JsResult.Exception
 import presentation.controllers.UpdateTaskRequest
 
 import javax.inject.{ Inject, Singleton }
@@ -14,22 +16,26 @@ class UpdateTaskUseCase @Inject() (
   implicit val executionContext: ExecutionContext
 ) {
   def execute(updateTaskRequest: UpdateTaskRequest): Future[TaskItemDto] = {
-    val newTask        = Task(
+    val requestTask      = Task(
       id         = Some(updateTaskRequest.id),
       categoryId = updateTaskRequest.categoryId,
       title      = updateTaskRequest.title,
       body       = updateTaskRequest.body,
       state      = updateTaskRequest.state
     )
-    val execution      = taskRepository.update(newTask.toEmbeddedId)
-    val categoryFuture = newTask.categoryId.fold(Future.successful(none[Category]))(taskQueryService.getCategoryById)
+    val resultTaskFuture = taskRepository.update(requestTask.toEmbeddedId).flatMap {
+      _.fold(Future.failed[Task#EmbeddedId](Exception(JsError("Failed to update the task on DB. "))))(Future.successful)
+    }
+    val categoryFuture   = requestTask.categoryId.fold(Future.successful(none[Category]))(taskQueryService.getCategoryById)
     for {
-      _        <- execution
-      category <- categoryFuture
+      resultTask <- resultTaskFuture
+      category   <- categoryFuture
     } yield TaskItemDto(
-      title         = newTask.title,
-      body          = newTask.body,
-      state         = newTask.state,
+      id            = resultTask.id,
+      title         = resultTask.v.title,
+      body          = resultTask.v.body,
+      state         = resultTask.v.state,
+      categoryId    = requestTask.categoryId,
       categoryName  = category.map(_.name),
       categoryColor = category.map(_.color)
     )

--- a/conf/routes
+++ b/conf/routes
@@ -11,3 +11,4 @@ GET     /assets/*file                 controllers.Assets.versioned(path="/public
 
 # Task
 POST    /task                         presentation.controllers.TaskController.add()
+PUT     /task                         presentation.controllers.TaskController.update()


### PR DESCRIPTION
### やったこと
- ToDoリストにポップアップ画面を開く編集ボタンを追加
- ポップアップ画面に更新の入力フォーム
  - デフォルトでオリジナルのデータが格納されている
  - 更新ボタンより、ToDoリストが更新され、画面が非同期に反映される
  - リセットボタンより、デフォルトのデータに戻る
  - 閉じるボタンより、ポップアップ画面が閉じる
- バリデーションとエラー処理は追加機能と同じ

https://github.com/user-attachments/assets/178d9bce-bcf2-400b-b9c8-264187e6f32c
